### PR TITLE
Fix some edge cases for the unanswered issues tab

### DIFF
--- a/features/dashboard/shared/issues/services/categorize-issues.service.ts
+++ b/features/dashboard/shared/issues/services/categorize-issues.service.ts
@@ -7,12 +7,30 @@ export async function categorizeIssues(
   rawIssues: RawIssue[],
   archivedIssues: Issue[]
 ): Promise<CategorizedProjectIssues> {
+  const liveIssueNumbers = new Set(
+    rawIssues.map(issue => issue.issueNumber)
+  );
+
+  const activeArchivedIssues = archivedIssues.filter(issue =>
+    liveIssueNumbers.has(issue.issueNumber)
+  );
+
+  const staleArchivedIssues = archivedIssues.filter(
+    issue => !liveIssueNumbers.has(issue.issueNumber)
+  );
+
+  await Promise.all(
+    staleArchivedIssues.map(issue =>
+      unarchiveIssue(issue.issueNumber)
+    )
+  );
+
   const result: CategorizedProjectIssues = {
     core: [],
     leap: [],
     dev: [],
     others: [],
-    archive: [...archivedIssues],
+    archive: [...activeArchivedIssues],
   };
 
   for (const rawIssue of rawIssues) {

--- a/features/dashboard/shared/unanswered-issues.tab.tsx
+++ b/features/dashboard/shared/unanswered-issues.tab.tsx
@@ -22,6 +22,13 @@ export default function UnansweredIssuesTab() {
 
   const [archivedIssues, setArchivedIssues] = useState<Issue[]>([]);
 
+  const teamLabelMap: Record<string, string> = {
+    leap: "LEAP Team",
+    core: "CORE Team",
+    dev: "Dev Workflow Team",
+    others: "Others",
+  };
+
   const handleClick = async () => {
     startLoading();
     try {
@@ -77,6 +84,27 @@ export default function UnansweredIssuesTab() {
             Load Issues
           </button>
         )}
+
+        {issues &&
+          responseData &&
+          activeTab !== "archive" &&
+          issues[activeTab].length === 0 && (
+            <div className="py-20 text-center">
+              <div className="mx-auto flex w-fit items-center gap-2 rounded-full bg-slate-100 px-4 py-1 text-sm font-medium text-slate-700">
+                <span>🎉</span>
+                <span>All issues cleared</span>
+              </div>
+
+              <p className="mt-5 text-2xl font-semibold tracking-tight text-slate-900">
+                Great job, {teamLabelMap[activeTab]} leads! 🙌
+              </p>
+
+              <p className="mx-auto mt-3 max-w-2xl text-sm leading-6 text-slate-600">
+                Big thanks for staying responsive and keeping your team&apos;s issue flow healthy.
+                Your consistency is helping keep the Oppia community active, supported, and moving forward.
+              </p>
+            </div>
+          )}
 
         {issues &&
           issues[activeTab].map((issue, index) => (

--- a/features/dashboard/shared/unanswered-issues.tab.tsx
+++ b/features/dashboard/shared/unanswered-issues.tab.tsx
@@ -26,7 +26,7 @@ export default function UnansweredIssuesTab() {
     leap: "LEAP Team",
     core: "CORE Team",
     dev: "Dev Workflow Team",
-    others: "Others",
+    others: "",
   };
 
   const handleClick = async () => {


### PR DESCRIPTION
- When team issues to respond used to be 0, there was a blank screen. Added an appreciation message for the team leads
- Issues that got closed were also showing up in the archive tab. Added an issue number check on the archive tab list, which is the issues fetched from the archive tab backend, should exist in the GitHub API response.

<img width="1919" height="1011" alt="image" src="https://github.com/user-attachments/assets/9287a28f-46dd-490c-b041-249d2f1ebc91" />

<img width="1919" height="1011" alt="image" src="https://github.com/user-attachments/assets/02957f5d-26de-49d8-b72b-512f2fb60164" />
