### PR TITLE
Updated Auth provider to GitHub

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -24,7 +24,7 @@ export default function LoginPage() {
 
   const handleSignIn = async () => {
     setLoading(true);
-    await signIn("google", { callbackUrl: "/dashboard" });
+    await signIn("github", { callbackUrl: "/dashboard" });
   };
 
   if (status === "loading") {
@@ -64,7 +64,7 @@ export default function LoginPage() {
                 Sign in
               </h2>
               <p className="mt-1 text-slate-500">
-                Access your Oppia dashboard with Google.
+                Access your Oppia dashboard with GitHub.
               </p>
             </div>
 
@@ -77,13 +77,14 @@ export default function LoginPage() {
                 <span className="animate-pulse">Signing you in...</span>
               ) : (
                 <>
-                  <Image
-                    src="https://www.svgrepo.com/show/475656/google-color.svg"
-                    alt="Google"
-                    width={20}
-                    height={20}
-                  />
-                  <span>Continue with Google</span>
+                  <svg
+                    aria-hidden="true"
+                    viewBox="0 0 24 24"
+                    className="h-5 w-5 fill-slate-900"
+                  >
+                    <path d="M12 .5C5.649.5.5 5.649.5 12c0 5.094 3.292 9.416 7.86 10.94.575.106.785-.25.785-.556 0-.274-.01-1-.016-1.963-3.197.695-3.872-1.54-3.872-1.54-.523-1.33-1.277-1.684-1.277-1.684-1.044-.714.079-.699.079-.699 1.155.081 1.763 1.186 1.763 1.186 1.026 1.759 2.692 1.251 3.348.957.104-.743.401-1.251.729-1.539-2.552-.291-5.236-1.276-5.236-5.682 0-1.255.449-2.282 1.184-3.086-.119-.29-.513-1.462.112-3.048 0 0 .965-.309 3.162 1.179A10.98 10.98 0 0 1 12 6.032c.973.005 1.954.131 2.87.384 2.195-1.488 3.158-1.179 3.158-1.179.627 1.586.233 2.758.114 3.048.737.804 1.182 1.831 1.182 3.086 0 4.417-2.688 5.387-5.248 5.673.412.355.78 1.054.78 2.124 0 1.534-.014 2.772-.014 3.149 0 .309.207.668.79.555C20.21 21.412 23.5 17.092 23.5 12c0-6.351-5.149-11.5-11.5-11.5Z" />
+                  </svg>
+                  <span>Continue with GitHub</span>
                 </>
               )}
             </button>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,4 @@
-"use client";
-
-import { signIn } from "next-auth/react";
+import Link from "next/link";
 import { SiteFooter } from "@/components/layout/site-footer";
 
 type RoleCardProps = {
@@ -116,12 +114,12 @@ export default function Home() {
             </p>
 
             <div className="mt-10 flex flex-wrap items-center gap-4">
-              <button
-                onClick={() => signIn("github", { callbackUrl: "/dashboard" })}
+              <Link
+                href="/login"
                 className="cursor-pointer inline-flex items-center gap-2 rounded-lg bg-linear-to-r from-emerald-500 to-teal-500 px-8 py-4 text-sm font-semibold text-white shadow-xl transition-all hover:-translate-y-0.5 hover:shadow-2xl focus:outline-none focus:ring-2 focus:ring-emerald-400/60"
               >
                 Enter Dashboard →
-              </button>
+              </Link>
 
               <span className="text-sm text-muted-foreground">
                 Inclusive workflow • Role-based experience
@@ -231,12 +229,12 @@ export default function Home() {
             Start with the role you have today and progress with a system designed to support every contributor and maintainer.
           </p>
 
-          <button
-            onClick={() => signIn("github", { callbackUrl: "/dashboard" })}
+          <Link
+            href="/login"
             className="cursor-pointer mt-10 inline-flex items-center gap-2 rounded-lg bg-linear-to-r from-emerald-500 to-teal-500 px-8 py-4 text-sm font-semibold text-white shadow-xl transition-all hover:-translate-y-0.5 hover:shadow-2xl"
           >
             Sign in with GitHub →
-          </button>
+          </Link>
         </div>
       </section>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -52,7 +52,7 @@ const JOURNEY_CARDS: JourneyCardProps[] = [
   {
     step: "01",
     title: "Sign in",
-    description: "Join with your Google account and enter a role-based workspace.",
+    description: "Join with your GitHub account and enter a role-based workspace.",
   },
   {
     step: "02",
@@ -117,7 +117,7 @@ export default function Home() {
 
             <div className="mt-10 flex flex-wrap items-center gap-4">
               <button
-                onClick={() => signIn("google", { callbackUrl: "/dashboard" })}
+                onClick={() => signIn("github", { callbackUrl: "/dashboard" })}
                 className="cursor-pointer inline-flex items-center gap-2 rounded-lg bg-linear-to-r from-emerald-500 to-teal-500 px-8 py-4 text-sm font-semibold text-white shadow-xl transition-all hover:-translate-y-0.5 hover:shadow-2xl focus:outline-none focus:ring-2 focus:ring-emerald-400/60"
               >
                 Enter Dashboard →
@@ -232,10 +232,10 @@ export default function Home() {
           </p>
 
           <button
-            onClick={() => signIn("google", { callbackUrl: "/dashboard" })}
+            onClick={() => signIn("github", { callbackUrl: "/dashboard" })}
             className="cursor-pointer mt-10 inline-flex items-center gap-2 rounded-lg bg-linear-to-r from-emerald-500 to-teal-500 px-8 py-4 text-sm font-semibold text-white shadow-xl transition-all hover:-translate-y-0.5 hover:shadow-2xl"
           >
-            Sign in with Google →
+            Sign in with GitHub →
           </button>
         </div>
       </section>

--- a/features/dashboard/shared/unanswered-issues.tab.tsx
+++ b/features/dashboard/shared/unanswered-issues.tab.tsx
@@ -26,11 +26,6 @@ export default function UnansweredIssuesTab() {
   const { data: session } = useSession();
   const platform = session?.user.platform;
 
-  if (!platform) {
-    console.error("User platform is undefined. Platform is required to load issues.");
-    return;
-  }
-
   const teamLabelMap: Record<string, string> =
     platform === "ANDROID"
       ? {

--- a/lib/auth/auth.options.ts
+++ b/lib/auth/auth.options.ts
@@ -11,6 +11,9 @@ import { ContributionPlatform } from "./auth.types";
 
 export const authOptions = {
   secret: process.env.NEXTAUTH_SECRET,
+  session: {
+    maxAge: 7 * 24 * 60 * 60,
+  },
 
   providers: [
     GitHubProvider({
@@ -27,13 +30,12 @@ export const authOptions = {
     }: {
       user: User;
       account: Account | null;
-      profile?: Profile;
+      profile: Profile & { login: string };
     }) {
       if (!user.email) return false;
 
       const subjectId = account?.providerAccountId;
-      const githubUsername =
-        typeof profile?.login === "string" ? profile.login : null;
+      const githubUsername = profile.login;
 
       if (!subjectId) return false;
 

--- a/lib/auth/auth.options.ts
+++ b/lib/auth/auth.options.ts
@@ -1,9 +1,10 @@
-import GoogleProvider from "next-auth/providers/google";
+import GitHubProvider from "next-auth/providers/github";
 import {
   createUserIfNotExists,
   getUserById,
 } from "@/db/users.db";
 import type { JWT } from "next-auth/jwt";
+import type { Profile } from "next-auth";
 import type { Account, Session, User } from "next-auth";
 import { UserRole } from "./auth.types";
 import { ContributionPlatform } from "./auth.types";
@@ -12,9 +13,9 @@ export const authOptions = {
   secret: process.env.NEXTAUTH_SECRET,
 
   providers: [
-    GoogleProvider({
-      clientId: process.env.GOOGLE_CLIENT_ID!,
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+    GitHubProvider({
+      clientId: process.env.GITHUB_ID!,
+      clientSecret: process.env.GITHUB_SECRET!,
     }),
   ],
 
@@ -22,13 +23,17 @@ export const authOptions = {
     async signIn({
       user,
       account,
+      profile,
     }: {
       user: User;
       account: Account | null;
+      profile?: Profile;
     }) {
       if (!user.email) return false;
 
       const subjectId = account?.providerAccountId;
+      const githubUsername =
+        typeof profile?.login === "string" ? profile.login : null;
 
       if (!subjectId) return false;
 
@@ -36,7 +41,7 @@ export const authOptions = {
         email: user.email,
         fullName: user.name ?? "",
         photoURL: user.image ?? "",
-        githubUsername: null,
+        githubUsername,
         role: "CONTRIBUTOR",
         team: null,
         platform: null,


### PR DESCRIPTION
- Added GitHub as an Auth provider because:
  - Reduces the GitHub name verification process
  - Meets our target audience
- Removed Google as an Auth provider 
- Reduced session maxAge to 7 days
- Updated dashboard page sign-in buttons redirection to the login page


https://github.com/user-attachments/assets/a9645f71-ce76-4114-a3df-70cb70816ce7

