### PR TITLE
fix(auth): exclude NextAuth routes from auth middleware

### DIFF
--- a/lib/auth/auth.options.ts
+++ b/lib/auth/auth.options.ts
@@ -9,6 +9,7 @@ import {
 
 export const authOptions: AuthOptions = {
   secret: readEnv("NEXTAUTH_SECRET"),
+  debug: process.env.NODE_ENV === "development",
   session: {
     maxAge: 7 * 24 * 60 * 60,
   },
@@ -28,6 +29,20 @@ export const authOptions: AuthOptions = {
 
     async session({ session, token }) {
       return handleAuthSession(session, token);
+    },
+  },
+  logger: {
+    error(code, metadata) {
+      console.error("[next-auth][logger][error]", code, {
+        ...metadata,
+        cause:
+          metadata &&
+          "error" in metadata &&
+          metadata.error instanceof Error &&
+          "cause" in metadata.error
+            ? metadata.error.cause
+            : undefined,
+      });
     },
   },
 };

--- a/lib/auth/auth.options.ts
+++ b/lib/auth/auth.options.ts
@@ -9,7 +9,6 @@ import {
 
 export const authOptions: AuthOptions = {
   secret: readEnv("NEXTAUTH_SECRET"),
-  debug: process.env.NODE_ENV === "development",
   session: {
     maxAge: 7 * 24 * 60 * 60,
   },
@@ -29,20 +28,6 @@ export const authOptions: AuthOptions = {
 
     async session({ session, token }) {
       return handleAuthSession(session, token);
-    },
-  },
-  logger: {
-    error(code, metadata) {
-      console.error("[next-auth][logger][error]", code, {
-        ...metadata,
-        cause:
-          metadata &&
-          "error" in metadata &&
-          metadata.error instanceof Error &&
-          "cause" in metadata.error
-            ? metadata.error.cause
-            : undefined,
-      });
     },
   },
 };

--- a/proxy.ts
+++ b/proxy.ts
@@ -98,5 +98,5 @@ export default withAuth(
 );
 
 export const config = {
-  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+  matcher: ["/((?!api/auth|_next/static|_next/image|favicon.ico).*)"],
 };


### PR DESCRIPTION
 The error was OAuthCallbackError: fetch failed during GET /api/auth/callback/github.

  What caused the failure:

  - `proxy.ts` used a broad matcher that included `/api/auth/callback/github`.
  - That meant withAuth was intercepting requests that NextAuth expects to handle itself.
  - OAuth callback routes are sensitive because they rely on state cookies, redirects, and an uninterrupted request/response flow.
  - Once middleware touched those routes, the callback flow became unstable and NextAuth surfaced the failure as fetch failed.

  So the fix was to exclude `/api/auth` from the middleware matcher in `proxy.ts`. 

