### PR TITLE
Fix #55: Add archivedBy, archivedAt fields and remove redundant isArchived from Firestore

### DIFF
--- a/app/api/archived-issues/route.ts
+++ b/app/api/archived-issues/route.ts
@@ -71,7 +71,7 @@ export async function POST(req: Request) {
     );
   }
 
-  await archiveIssue(body.issue, platform);
+  await archiveIssue(body.issue, platform, session.user.githubUsername);
   return NextResponse.json({ success: true });
 }
 

--- a/db/archived-issues/archived-issues.db.ts
+++ b/db/archived-issues/archived-issues.db.ts
@@ -61,13 +61,7 @@ export async function archiveIssue(
 ): Promise<void> {
   await archivedIssuesCollection
     .doc(getArchivedIssueDocId(platform, issue.issueNumber))
-    .set(
-      serializeArchivedIssue(
-        { ...issue, isArchived: true },
-        platform,
-        archivedBy,
-      ),
-    );
+    .set(serializeArchivedIssue(issue, platform, archivedBy));
 }
 
 /**

--- a/db/archived-issues/archived-issues.db.ts
+++ b/db/archived-issues/archived-issues.db.ts
@@ -57,7 +57,7 @@ export async function getArchivedIssues(
 export async function archiveIssue(
   issue: Issue,
   platform: ContributionPlatform,
-  archivedBy?: string,
+  archivedBy: string,
 ): Promise<void> {
   await archivedIssuesCollection
     .doc(getArchivedIssueDocId(platform, issue.issueNumber))

--- a/db/archived-issues/archived-issues.db.ts
+++ b/db/archived-issues/archived-issues.db.ts
@@ -51,15 +51,23 @@ export async function getArchivedIssues(
  *
  * @param issue The issue to archive.
  * @param platform The contribution platform that owns the archive entry.
+ * @param archivedBy The GitHub username of the user who archived the issue.
  * @returns A promise that resolves when the archive record has been written.
  */
 export async function archiveIssue(
   issue: Issue,
   platform: ContributionPlatform,
+  archivedBy?: string,
 ): Promise<void> {
   await archivedIssuesCollection
     .doc(getArchivedIssueDocId(platform, issue.issueNumber))
-    .set(serializeArchivedIssue({ ...issue, isArchived: true }, platform));
+    .set(
+      serializeArchivedIssue(
+        { ...issue, isArchived: true },
+        platform,
+        archivedBy,
+      ),
+    );
 }
 
 /**

--- a/db/archived-issues/archived-issues.mapper.ts
+++ b/db/archived-issues/archived-issues.mapper.ts
@@ -11,7 +11,7 @@ export type FirestoreArchivedIssue = {
   issueNumber: number;
   issueUrl: string;
   issueTitle: string;
-  isArchived: boolean;
+  isArchived?: boolean;
   lastCommentCreatedAt: Timestamp;
   linkedProject: string;
   platform: ContributionPlatform;
@@ -53,7 +53,7 @@ function assertFirestoreArchivedIssue(
     );
   }
 
-  if (typeof issue.isArchived !== "boolean") {
+  if (issue.isArchived !== undefined && typeof issue.isArchived !== "boolean") {
     throw new DbValidationError(
       "isArchived",
       "Archived issue isArchived must be a boolean.",
@@ -105,7 +105,7 @@ function normalizeArchivedIssue(
     issueNumber: issue.issueNumber,
     issueUrl: issue.issueUrl,
     issueTitle: issue.issueTitle,
-    isArchived: issue.isArchived,
+    isArchived: true,
     lastCommentCreatedAt: normalizeTimestamp(
       issue.lastCommentCreatedAt,
     ).toISOString(),
@@ -148,7 +148,6 @@ export function serializeArchivedIssue(
     issueNumber: issue.issueNumber,
     issueUrl: issue.issueUrl,
     issueTitle: issue.issueTitle,
-    isArchived: issue.isArchived,
     lastCommentCreatedAt: Timestamp.fromDate(
       new Date(issue.lastCommentCreatedAt),
     ),

--- a/db/archived-issues/archived-issues.mapper.ts
+++ b/db/archived-issues/archived-issues.mapper.ts
@@ -7,9 +7,16 @@ import {
   normalizeTimestamp,
 } from "@/db/utils/timestamp.utils";
 
-export type FirestoreArchivedIssue = Omit<Issue, "lastCommentCreatedAt"> & {
+export type FirestoreArchivedIssue = {
+  issueNumber: number;
+  issueUrl: string;
+  issueTitle: string;
+  isArchived: boolean;
   lastCommentCreatedAt: Timestamp;
+  linkedProject: string;
   platform: ContributionPlatform;
+  archivedBy?: string;
+  archivedAt?: Timestamp;
 };
 
 export type ArchivedIssueRecord = Issue & {
@@ -72,6 +79,17 @@ function assertFirestoreArchivedIssue(
       "Archived issue platform must be WEB or ANDROID.",
     );
   }
+
+  if (issue.archivedBy !== undefined && typeof issue.archivedBy !== "string") {
+    throw new DbValidationError(
+      "archivedBy",
+      "Archived issue archivedBy must be a string.",
+    );
+  }
+
+  if (issue.archivedAt !== undefined) {
+    assertTimestamp("Archived issue", "archivedAt", issue.archivedAt);
+  }
 }
 
 /**
@@ -93,6 +111,10 @@ function normalizeArchivedIssue(
     ).toISOString(),
     linkedProject: issue.linkedProject,
     platform: issue.platform,
+    archivedBy: issue.archivedBy,
+    archivedAt: issue.archivedAt
+      ? normalizeTimestamp(issue.archivedAt).toISOString()
+      : undefined,
   };
 }
 
@@ -114,11 +136,13 @@ export function normalizeArchivedIssueDocument(
  *
  * @param issue The normalized archived issue.
  * @param platform The contribution platform to persist.
+ * @param archivedBy The GitHub username of the user who archived the issue.
  * @returns The Firestore-ready archived issue document.
  */
 export function serializeArchivedIssue(
   issue: Issue,
   platform: ContributionPlatform,
+  archivedBy?: string,
 ): FirestoreArchivedIssue {
   return {
     issueNumber: issue.issueNumber,
@@ -130,5 +154,7 @@ export function serializeArchivedIssue(
     ),
     linkedProject: issue.linkedProject,
     platform,
+    archivedBy,
+    archivedAt: Timestamp.now(),
   };
 }

--- a/db/archived-issues/archived-issues.mapper.ts
+++ b/db/archived-issues/archived-issues.mapper.ts
@@ -142,7 +142,7 @@ export function normalizeArchivedIssueDocument(
 export function serializeArchivedIssue(
   issue: Issue,
   platform: ContributionPlatform,
-  archivedBy?: string,
+  archivedBy: string,
 ): FirestoreArchivedIssue {
   return {
     issueNumber: issue.issueNumber,

--- a/db/db-schema.md
+++ b/db/db-schema.md
@@ -49,13 +49,8 @@ Fields:
 - `lastCommentCreatedAt: Timestamp`
 - `linkedProject: string`
 - `platform: "WEB" | "ANDROID"`
-- `archivedBy: string` **(GitHub username of the lead who archived the issue; absent in legacy records)**
-- `archivedAt: Timestamp` **(When the issue was archived; absent in legacy records)**
-
-Notes:
-
-- `isArchived` was previously persisted but has been removed — the collection itself implies archived state. On read, `normalizeArchivedIssue` always sets `isArchived: true`.
-- `archivedBy` and `archivedAt` are set server-side on archive; absent in legacy documents
+- `archivedBy: string`
+- `archivedAt: Timestamp`
 
 ### `memberAccessRequests`
 

--- a/db/db-schema.md
+++ b/db/db-schema.md
@@ -46,17 +46,15 @@ Fields:
 - `issueNumber: number`
 - `issueUrl: string`
 - `issueTitle: string`
-- `isArchived: true` **(Audit if this field is needed or not)**
 - `lastCommentCreatedAt: Timestamp`
 - `linkedProject: string`
 - `platform: "WEB" | "ANDROID"`
-- `archivedBy: string | null` **(GitHub username of the lead who archived the issue; null for legacy records)**
-- `archivedAt: Timestamp | null` **(When the issue was archived; null for legacy records)**
+- `archivedBy: string` **(GitHub username of the lead who archived the issue; absent in legacy records)**
+- `archivedAt: Timestamp` **(When the issue was archived; absent in legacy records)**
 
 Notes:
 
-- this schema mirrors the shared `Issue` domain type plus `platform`
-- `isArchived` is currently persisted even though the collection itself already implies archived state
+- `isArchived` was previously persisted but has been removed — the collection itself implies archived state. On read, `normalizeArchivedIssue` always sets `isArchived: true`.
 - `archivedBy` and `archivedAt` are set server-side on archive; absent in legacy documents
 
 ### `memberAccessRequests`

--- a/db/db-schema.md
+++ b/db/db-schema.md
@@ -50,11 +50,14 @@ Fields:
 - `lastCommentCreatedAt: Timestamp`
 - `linkedProject: string`
 - `platform: "WEB" | "ANDROID"`
+- `archivedBy: string | null` **(GitHub username of the lead who archived the issue; null for legacy records)**
+- `archivedAt: Timestamp | null` **(When the issue was archived; null for legacy records)**
 
 Notes:
 
-- this schema currently mirrors the shared `Issue` domain type plus `platform`
+- this schema mirrors the shared `Issue` domain type plus `platform`
 - `isArchived` is currently persisted even though the collection itself already implies archived state
+- `archivedBy` and `archivedAt` are set server-side on archive; absent in legacy documents
 
 ### `memberAccessRequests`
 

--- a/features/dashboard/shared/issues/components/issue-card.tsx
+++ b/features/dashboard/shared/issues/components/issue-card.tsx
@@ -45,11 +45,21 @@ export const IssueCard = ({ issue, serialNumber }: IssueCardProps) => {
           </CardTitle>
           <CardDescription className="space-y-1">
             <p>{`#${issue.issueNumber}`}</p>
-            {!issue.isArchived && (
+            {!issue.isArchived ? (
               <p className="text-xs text-slate-600">
                 Waiting {waitedForLabel} since last comment
               </p>
-            )}
+            ) : issue.archivedBy || issue.archivedAt ? (
+              <p className="text-xs text-slate-500">
+                {issue.archivedBy && (
+                  <span>Archived by {issue.archivedBy}</span>
+                )}
+                {issue.archivedBy && issue.archivedAt && <span> · </span>}
+                {issue.archivedAt && (
+                  <span>{getElapsedTimeLabel(issue.archivedAt)} ago</span>
+                )}
+              </p>
+            ) : null}
           </CardDescription>
         </CardHeader>
       </Link>

--- a/features/dashboard/shared/issues/hooks/use-archive-issue.hook.ts
+++ b/features/dashboard/shared/issues/hooks/use-archive-issue.hook.ts
@@ -20,6 +20,8 @@ export function useArchiveIssue() {
       return;
     }
 
+    const githubUsername = session?.user?.githubUsername;
+
     await archiveIssueForPlatform(issue, platform);
 
     const from: keyof CategorizedProjectIssues = getIssueBucket(
@@ -27,6 +29,9 @@ export function useArchiveIssue() {
       issue.linkedProject,
     );
 
-    moveIssue(from, "archive", issue.issueNumber);
+    moveIssue(from, "archive", issue.issueNumber, {
+      archivedBy: githubUsername,
+      archivedAt: new Date().toISOString(),
+    });
   };
 }

--- a/features/dashboard/shared/issues/store/project-issues.store.ts
+++ b/features/dashboard/shared/issues/store/project-issues.store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import type { Issue } from "@/lib/domain/issues.types";
 import { CategorizedProjectIssues } from "../../../dashboard.types";
 
 interface ProjectIssuesStore {
@@ -8,6 +9,7 @@ interface ProjectIssuesStore {
     from: keyof CategorizedProjectIssues,
     to: keyof CategorizedProjectIssues,
     issueNumber: number,
+    metadata?: Partial<Pick<Issue, "archivedBy" | "archivedAt">>,
   ) => void;
   removeIssue: (
     from: keyof CategorizedProjectIssues,
@@ -29,7 +31,7 @@ export const useProjectIssuesStore = create<ProjectIssuesStore>((set) => ({
       issues: newIssues,
     }),
 
-  moveIssue: (from, to, issueNumber) =>
+  moveIssue: (from, to, issueNumber, metadata) =>
     set((state) => {
       const issueToMove = state.issues[from].find(
         (i) => i.issueNumber === issueNumber,
@@ -37,7 +39,11 @@ export const useProjectIssuesStore = create<ProjectIssuesStore>((set) => ({
 
       if (!issueToMove) return {};
 
-      const updatedIssue = { ...issueToMove, isArchived: true };
+      const updatedIssue = {
+        ...issueToMove,
+        isArchived: true,
+        ...metadata,
+      };
 
       return {
         issues: {

--- a/lib/data-jobs/data-jobs.service.ts
+++ b/lib/data-jobs/data-jobs.service.ts
@@ -1,3 +1,4 @@
+import { Timestamp, FieldValue } from "firebase-admin/firestore";
 import { DbNotFoundError } from "@/db/db.errors";
 import {
   createDataJobRun,
@@ -6,7 +7,9 @@ import {
   markDataJobRunFailed,
   markDataJobRunSucceeded,
 } from "@/db/data-jobs/data-job-runs.db";
+import { getAdminFirestore } from "@/lib/firebase/firebase-admin";
 import { getAllUsers } from "@/db/users/users.db";
+import { DB_PATHS } from "@/db/db-paths";
 import type {
   DataJobDefinition,
   DataJobResult,
@@ -20,6 +23,7 @@ type DataJobActor = {
 
 type DataJobHandlerContext = {
   dryRun: boolean;
+  triggeredByGithubUsername: string;
 };
 
 type DataJobHandler = (
@@ -80,6 +84,58 @@ async function auditPrivilegedUsersMissingTeam(
   };
 }
 
+/**
+ * Backfills archived issue documents:
+ *   - Removes the redundant `isArchived` field
+ *   - Adds `archivedBy` and `archivedAt` to legacy records that lack them
+ *
+ * @param context The data-job execution context.
+ * @returns A summary of the migration results.
+ */
+async function backfillArchivedIssues(
+  context: DataJobHandlerContext,
+): Promise<DataJobResult> {
+  const db = getAdminFirestore();
+  const snapshot = await db
+    .collection(DB_PATHS.ARCHIVED_ISSUES.COLLECTION)
+    .get();
+
+  let updatedCount = 0;
+
+  for (const doc of snapshot.docs) {
+    const data = doc.data();
+    const updates: Record<string, string | Timestamp | FieldValue> = {};
+
+    if (data.isArchived !== undefined) {
+      updates.isArchived = FieldValue.delete();
+    }
+
+    if (data.archivedBy === undefined) {
+      updates.archivedBy = context.triggeredByGithubUsername;
+    }
+
+    if (data.archivedAt === undefined) {
+      updates.archivedAt = Timestamp.now();
+    }
+
+    if (Object.keys(updates).length === 0) {
+      continue;
+    }
+
+    updatedCount++;
+
+    if (!context.dryRun) {
+      await doc.ref.update(updates);
+    }
+  }
+
+  const suffix = context.dryRun ? " (dry run — no changes persisted)" : ".";
+
+  return {
+    summary: `Backfill completed. ${updatedCount} document(s) updated${suffix}`,
+  };
+}
+
 const DATA_JOB_REGISTRY: RegisteredDataJob[] = [
   {
     key: "audit_users_missing_platform",
@@ -98,6 +154,15 @@ const DATA_JOB_REGISTRY: RegisteredDataJob[] = [
     kind: "AUDIT",
     supportsDryRun: true,
     handler: auditPrivilegedUsersMissingTeam,
+  },
+  {
+    key: "backfill_archived_issues",
+    name: "Backfill Archived Issues",
+    description:
+      "Removes the redundant isArchived field and adds archivedBy + archivedAt to legacy archived issue documents.",
+    kind: "MIGRATION",
+    supportsDryRun: true,
+    handler: backfillArchivedIssues,
   },
 ];
 
@@ -161,7 +226,10 @@ export async function runDataJob(
   });
 
   try {
-    const result = await job.handler({ dryRun });
+    const result = await job.handler({
+      dryRun,
+      triggeredByGithubUsername: actor.githubUsername,
+    });
     await markDataJobRunSucceeded(runId, result.summary);
   } catch (error) {
     const errorMessage =

--- a/lib/domain/issues.types.ts
+++ b/lib/domain/issues.types.ts
@@ -5,4 +5,6 @@ export interface Issue {
   isArchived: boolean;
   lastCommentCreatedAt: string;
   linkedProject: string;
+  archivedBy?: string;
+  archivedAt?: string;
 }


### PR DESCRIPTION
- Fix #55
- Added `archivedBy` and `archivedAt` fields in the archiveIssues collection
- Removed `isArchived` field from the archiveIssues collection
- Added a data job to backfill the existing archiveIssues data

<img width="1904" height="958" alt="image" src="https://github.com/user-attachments/assets/ecc7e13c-76d1-47f0-a085-df9b5f47c30c" />


https://github.com/user-attachments/assets/0549b562-3f10-4173-8a6b-fa23dca1681d

