### PR TITLE
Fix #53: Add org-meta collection to cache GitHub org members and collaborators

### DIFF
--- a/app/api/cron/sync-org-meta/route.ts
+++ b/app/api/cron/sync-org-meta/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { readEnv } from "@/lib/config";
+import { syncOrgMeta } from "@/lib/org-meta/sync-org-meta.service";
+
+function isAuthorizedCronRequest(req: Request): boolean {
+  const cronSecret = readEnv("CRON_SECRET");
+
+  if (!cronSecret) {
+    return false;
+  }
+
+  const authorization = req.headers.get("authorization");
+  return authorization === `Bearer ${cronSecret}`;
+}
+
+export async function GET(req: Request) {
+  if (!isAuthorizedCronRequest(req)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const summary = await syncOrgMeta();
+    return NextResponse.json(summary);
+  } catch (error) {
+    console.error(error);
+
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error ? error.message : "Failed to sync org meta.",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/github/issues/route.ts
+++ b/app/api/github/issues/route.ts
@@ -33,7 +33,7 @@ export async function GET() {
       );
     }
 
-    const issuesData = await fetchUnansweredIssues(repoTarget);
+    const issuesData = await fetchUnansweredIssues(repoTarget, platform);
     return NextResponse.json({
       issues: issuesData,
     });

--- a/db/db-paths.ts
+++ b/db/db-paths.ts
@@ -21,4 +21,7 @@ export const DB_PATHS = {
     COLLECTION: "users",
     NOTIFICATIONS_SUBCOLLECTION: "notifications",
   },
+  ORG_META: {
+    COLLECTION: "orgMeta",
+  },
 } as const;

--- a/db/db-schema.md
+++ b/db/db-schema.md
@@ -121,6 +121,21 @@ Fields:
 - `startedAt: Timestamp`
 - `finishedAt: Timestamp | null`
 
+### `orgMeta`
+
+Document id:
+
+- platform string (`WEB` or `ANDROID`)
+
+Fields:
+
+- `orgMembers: string[]` — GitHub usernames of organization members (via `membersWithRole`)
+- `collaborators: Array<{ login: string, permission: string }>` — Repository collaborators with their permission level
+- `lastUpdated: Timestamp`
+
+This collection is populated by a cron job (`/api/cron/sync-org-meta`) that runs every 3 days at 3 AM IST.
+The cached data is used by the unanswered-issues fetcher to avoid fetching org/collaborator data from the GitHub API on every request.
+
 ## Derived Type Summary
 
 Normalized app-layer models convert Firestore timestamps as follows:

--- a/db/org-meta/org-meta.db.ts
+++ b/db/org-meta/org-meta.db.ts
@@ -1,0 +1,52 @@
+import { getAdminFirestore } from "@/lib/firebase/firebase-admin";
+import type { ContributionPlatform } from "@/lib/auth/auth.types";
+import { DB_PATHS } from "@/db/db-paths";
+import {
+  type FirestoreOrgMeta,
+  type OrgMetaRecord,
+  normalizeOrgMetaDocument,
+  serializeOrgMeta,
+} from "./org-meta.mapper";
+
+const db = getAdminFirestore();
+const orgMetaCollection = db.collection(
+  DB_PATHS.ORG_META.COLLECTION,
+) as FirebaseFirestore.CollectionReference<FirestoreOrgMeta>;
+
+/**
+ * Retrieves org meta for a given platform.
+ *
+ * @param platform The contribution platform.
+ * @returns The org meta record, or null if not stored.
+ */
+export async function getOrgMeta(
+  platform: ContributionPlatform,
+): Promise<OrgMetaRecord | null> {
+  const snapshot = await orgMetaCollection.doc(platform).get();
+
+  if (!snapshot.exists) {
+    return null;
+  }
+
+  const data = snapshot.data();
+
+  if (!data) {
+    return null;
+  }
+
+  return normalizeOrgMetaDocument(data);
+}
+
+/**
+ * Stores or replaces org meta for a given platform.
+ *
+ * @param platform The contribution platform.
+ * @param orgMeta The org meta to persist.
+ * @returns A promise that resolves when the write completes.
+ */
+export async function upsertOrgMeta(
+  platform: ContributionPlatform,
+  orgMeta: OrgMetaRecord,
+): Promise<void> {
+  await orgMetaCollection.doc(platform).set(serializeOrgMeta(orgMeta));
+}

--- a/db/org-meta/org-meta.mapper.ts
+++ b/db/org-meta/org-meta.mapper.ts
@@ -1,0 +1,106 @@
+import { Timestamp } from "firebase-admin/firestore";
+import { DbValidationError } from "@/db/db.errors";
+import {
+  assertTimestamp,
+  normalizeTimestamp,
+} from "@/db/utils/timestamp.utils";
+
+export type CollaboratorEntry = {
+  login: string;
+  permission: string;
+};
+
+export type FirestoreOrgMeta = {
+  orgMembers: string[];
+  collaborators: CollaboratorEntry[];
+  lastUpdated: Timestamp;
+};
+
+export type OrgMetaRecord = {
+  orgMembers: string[];
+  collaborators: CollaboratorEntry[];
+  lastUpdated: Date;
+};
+
+/**
+ * Validates the raw Firestore org-meta document shape.
+ *
+ * @param data The raw Firestore org-meta document data.
+ * @returns Nothing. Throws when the document shape is invalid.
+ */
+function assertFirestoreOrgMeta(
+  data: FirebaseFirestore.DocumentData,
+): asserts data is FirestoreOrgMeta {
+  if (
+    !Array.isArray(data.orgMembers) ||
+    !data.orgMembers.every((m) => typeof m === "string")
+  ) {
+    throw new DbValidationError(
+      "orgMembers",
+      "orgMembers must be an array of strings.",
+    );
+  }
+
+  if (!Array.isArray(data.collaborators)) {
+    throw new DbValidationError(
+      "collaborators",
+      "collaborators must be an array.",
+    );
+  }
+
+  for (const entry of data.collaborators) {
+    if (typeof entry.login !== "string") {
+      throw new DbValidationError(
+        "collaborators.login",
+        "Each collaborator entry must have a login string.",
+      );
+    }
+    if (typeof entry.permission !== "string") {
+      throw new DbValidationError(
+        "collaborators.permission",
+        "Each collaborator entry must have a permission string.",
+      );
+    }
+  }
+
+  assertTimestamp("OrgMeta", "lastUpdated", data.lastUpdated);
+}
+
+/**
+ * Normalizes raw Firestore org-meta data into the app model.
+ *
+ * @param data The raw Firestore org-meta data.
+ * @returns The normalized org-meta record.
+ */
+export function normalizeOrgMetaDocument(
+  data: FirebaseFirestore.DocumentData,
+): OrgMetaRecord {
+  assertFirestoreOrgMeta(data);
+
+  return {
+    orgMembers: data.orgMembers,
+    collaborators: data.collaborators,
+    lastUpdated: normalizeTimestamp(data.lastUpdated),
+  };
+}
+
+/**
+ * Serializes an org-meta record for Firestore storage.
+ *
+ * @param orgMeta The org-meta record to persist.
+ * @returns The Firestore-ready org-meta document.
+ */
+export function serializeOrgMeta(
+  orgMeta: Omit<OrgMetaRecord, "lastUpdated"> & {
+    lastUpdated: Date | Timestamp;
+  },
+): FirestoreOrgMeta {
+  return {
+    orgMembers: orgMeta.orgMembers,
+    collaborators: orgMeta.collaborators,
+    lastUpdated:
+      orgMeta.lastUpdated instanceof Timestamp
+        ? orgMeta.lastUpdated
+        : Timestamp.fromDate(orgMeta.lastUpdated),
+  };
+}

--- a/lib/cron-jobs/manual-cron-jobs.service.ts
+++ b/lib/cron-jobs/manual-cron-jobs.service.ts
@@ -5,6 +5,7 @@ import type {
 import { LibInvalidStateError } from "@/lib/lib.errors";
 import { captureDailyUnansweredIssueMetrics } from "@/lib/team-metrics/capture-daily-team-metrics.service";
 import { syncTeamGfiCounts } from "@/lib/teams/sync-team-gfi-counts.service";
+import { syncOrgMeta } from "@/lib/org-meta/sync-org-meta.service";
 
 const CRON_JOBS: CronJobDefinition[] = [
   {
@@ -18,6 +19,12 @@ const CRON_JOBS: CronJobDefinition[] = [
     name: "Sync Team GFI Counts",
     description:
       "Fetch open unassigned good first issues from GitHub and update each team's gfiCounts.",
+  },
+  {
+    key: "sync_org_meta",
+    name: "Sync Org Meta",
+    description:
+      "Fetch org members and repo collaborators from GitHub and cache them in Firestore for faster unanswered-issues lookups.",
   },
 ];
 
@@ -82,6 +89,24 @@ export async function runCronJob(jobKey: string): Promise<CronJobRunResult> {
           `Updated teams: ${result.updatedTeamsCount}.`,
           `Total GFI issues scanned: ${result.totalIssuesCount}.`,
           `Skipped issues: ${result.skippedIssuesCount}.`,
+        ].join("\n"),
+      };
+    }
+    case "sync_org_meta": {
+      const result = await syncOrgMeta();
+      const finishedAt = new Date();
+
+      return {
+        finishedAt,
+        jobKey: job.key,
+        jobName: job.name,
+        startedAt,
+        summary: [
+          "Cron job completed.",
+          `Platforms: ${result.platforms.join(", ")}.`,
+          `Org members: ${result.orgMemberCount}.`,
+          `Collaborators: ${result.collaboratorCount}.`,
+          `Last updated: ${result.lastUpdated}.`,
         ].join("\n"),
       };
     }

--- a/lib/github/github-unanswered-issues.fetcher.ts
+++ b/lib/github/github-unanswered-issues.fetcher.ts
@@ -1,3 +1,5 @@
+import { getOrgMeta } from "@/db/org-meta/org-meta.db";
+import type { ContributionPlatform } from "@/lib/auth/auth.types";
 import { mapGitHubIssueNodes } from "./github-issues.mapper";
 import {
   fetchOrgAndCollaboratorAccess,
@@ -10,26 +12,59 @@ import type { GitHubIssue, GitHubRepoTarget } from "./github.types";
  * Fetches unanswered issues whose latest recent comment came from a non-maintainer.
  *
  * @param target The GitHub repository to inspect.
+ * @param platform Optional platform to fetch cached org meta from Firestore.
  * @returns The filtered unanswered issue nodes for the dashboard.
  */
 export async function fetchUnansweredIssues(
   target: GitHubRepoTarget,
+  platform?: ContributionPlatform,
 ): Promise<GitHubIssue[]> {
-  console.log("Fetching collaborators and org members...");
+  let orgMembers: Set<string>;
+  let collabAll: Set<string>;
+  let maintainers: Set<string>;
 
-  const orgData = await fetchOrgAndCollaboratorAccess(target);
-  const orgMembers = new Set(
-    orgData.organization.membersWithRole.nodes.map((member) => member.login),
-  );
-  const collaborators = orgData.repository.collaborators.edges;
-  const collabAll = new Set(collaborators.map((entry) => entry.node.login));
-  const maintainers = new Set(
-    collaborators
-      .filter((entry) =>
-        ["ADMIN", "MAINTAIN", "WRITE"].includes(entry.permission),
-      )
-      .map((entry) => entry.node.login),
-  );
+  if (platform) {
+    const cached = await getOrgMeta(platform);
+
+    if (cached) {
+      console.log("Using cached org meta from Firestore...");
+      orgMembers = new Set(cached.orgMembers);
+      collabAll = new Set(cached.collaborators.map((c) => c.login));
+      maintainers = new Set(
+        cached.collaborators
+          .filter((c) => ["ADMIN", "MAINTAIN", "WRITE"].includes(c.permission))
+          .map((c) => c.login),
+      );
+    } else {
+      console.log("No cached org meta found, falling back to GitHub API...");
+      const fetched = await fetchOrgAndCollaboratorAccess(target);
+      orgMembers = new Set(
+        fetched.organization.membersWithRole.nodes.map((m) => m.login),
+      );
+      const collabEdges = fetched.repository.collaborators.edges;
+      collabAll = new Set(collabEdges.map((e) => e.node.login));
+      maintainers = new Set(
+        collabEdges
+          .filter((e) => ["ADMIN", "MAINTAIN", "WRITE"].includes(e.permission))
+          .map((e) => e.node.login),
+      );
+    }
+  } else {
+    console.log("Fetching collaborators and org members from GitHub...");
+    const orgData = await fetchOrgAndCollaboratorAccess(target);
+    orgMembers = new Set(
+      orgData.organization.membersWithRole.nodes.map((member) => member.login),
+    );
+    const collaborators = orgData.repository.collaborators.edges;
+    collabAll = new Set(collaborators.map((entry) => entry.node.login));
+    maintainers = new Set(
+      collaborators
+        .filter((entry) =>
+          ["ADMIN", "MAINTAIN", "WRITE"].includes(entry.permission),
+        )
+        .map((entry) => entry.node.login),
+    );
+  }
 
   console.log(`Org members: ${orgMembers.size}`);
   console.log(`Collaborators: ${collabAll.size}`);

--- a/lib/github/github-unanswered-issues.fetcher.ts
+++ b/lib/github/github-unanswered-issues.fetcher.ts
@@ -70,11 +70,11 @@ export async function fetchUnansweredIssues(
   console.log(`Collaborators: ${collabAll.size}`);
   console.log(`Maintainers: ${maintainers.size}`);
 
-  console.log("Fetching recent issues (30-day window)...");
+  console.log("Fetching recent issues (15-day window)...");
   const issues = await fetchRecentIssueNodes(target);
   console.log(`Fetched ${issues.length} recent issues.`);
 
-  const cutoffTime = Date.now() - 30 * 86400 * 1000;
+  const cutoffTime = Date.now() - 15 * 86400 * 1000;
   const filtered = issues.filter((issue) => {
     if (issue.state === "CLOSED") {
       return false;
@@ -108,7 +108,7 @@ export async function fetchUnansweredIssues(
   });
 
   console.log(
-    "\nIssues where last comment in past 30 days is from non-maintainer",
+    "\nIssues where last comment in past 15 days is from non-maintainer",
   );
   console.log("----------------------------------------------------------");
   console.log(`\nTotal filtered issues: ${filtered.length}`);

--- a/lib/github/github.query-helpers.ts
+++ b/lib/github/github.query-helpers.ts
@@ -139,7 +139,7 @@ function assertOrgAndRepoAccessResponse(
 }
 
 /**
- * Fetches recent repository issues from the last 30 days using paginated GraphQL requests.
+ * Fetches recent repository issues from the last 15 days using paginated GraphQL requests.
  *
  * @param target The repository to fetch from.
  * @returns The aggregated recent issue nodes.
@@ -150,7 +150,7 @@ export async function fetchRecentIssueNodes(
   const issues: GitHubIssueNode[] = [];
   let cursor: string | null = null;
   let hasNextPage = true;
-  const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+  const since = new Date(Date.now() - 15 * 24 * 60 * 60 * 1000).toISOString();
 
   const query = `
     query($owner: String!, $repo: String!, $cursor: String, $since: DateTime!) {

--- a/lib/org-meta/sync-org-meta.service.ts
+++ b/lib/org-meta/sync-org-meta.service.ts
@@ -1,0 +1,73 @@
+import { GITHUB_REPOS } from "@/lib/config/github.constants";
+import { fetchOrgAndCollaboratorAccess } from "@/lib/github/github.query-helpers";
+import { upsertOrgMeta } from "@/db/org-meta/org-meta.db";
+import type { ContributionPlatform } from "@/lib/auth/auth.types";
+
+type SyncOrgMetaSummary = {
+  platforms: ContributionPlatform[];
+  orgMemberCount: number;
+  collaboratorCount: number;
+  lastUpdated: string;
+};
+
+type PlatformCounts = {
+  orgMemberCount: number;
+  collaboratorCount: number;
+};
+
+/**
+ * Fetches org members and collaborators from GitHub for a single platform
+ * and persists them to Firestore.
+ *
+ * @param platform The contribution platform to sync.
+ * @returns The counts of members and collaborators stored.
+ */
+async function syncPlatform(
+  platform: ContributionPlatform,
+): Promise<PlatformCounts> {
+  const target = GITHUB_REPOS[platform];
+  const orgData = await fetchOrgAndCollaboratorAccess(target);
+
+  const orgMembers = orgData.organization.membersWithRole.nodes.map(
+    (m) => m.login,
+  );
+
+  const collaborators = orgData.repository.collaborators.edges.map((entry) => ({
+    login: entry.node.login,
+    permission: entry.permission,
+  }));
+
+  await upsertOrgMeta(platform, {
+    orgMembers,
+    collaborators,
+    lastUpdated: new Date(),
+  });
+
+  return {
+    orgMemberCount: orgMembers.length,
+    collaboratorCount: collaborators.length,
+  };
+}
+
+/**
+ * Syncs org member and collaborator data from GitHub to Firestore
+ * for all platforms (WEB and ANDROID).
+ *
+ * Intended to be called by a cron job every 3 days at 3 AM IST.
+ *
+ * @returns A summary of what was synced.
+ */
+export async function syncOrgMeta(): Promise<SyncOrgMetaSummary> {
+  const platforms: ContributionPlatform[] = ["WEB", "ANDROID"];
+
+  const counts = await Promise.all(platforms.map(syncPlatform));
+
+  const lastUpdated = new Date().toISOString();
+
+  return {
+    platforms,
+    orgMemberCount: counts.reduce((sum, c) => sum + c.orgMemberCount, 0),
+    collaboratorCount: counts.reduce((sum, c) => sum + c.collaboratorCount, 0),
+    lastUpdated,
+  };
+}

--- a/lib/team-metrics/capture-daily-team-metrics.service.ts
+++ b/lib/team-metrics/capture-daily-team-metrics.service.ts
@@ -92,7 +92,7 @@ async function capturePlatformTeamMetrics(
   dateKey: string,
 ): Promise<TeamMetricCaptureSummary["teams"]> {
   const [liveIssues, archivedIssues] = await Promise.all([
-    fetchUnansweredIssues(GITHUB_REPOS[platform]),
+    fetchUnansweredIssues(GITHUB_REPOS[platform], platform),
     getArchivedIssues(platform),
   ]);
 

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,10 @@
     {
       "path": "/api/cron/sync-team-gfi-counts",
       "schedule": "0 0 * * *"
+    },
+    {
+      "path": "/api/cron/sync-org-meta",
+      "schedule": "30 21 */3 * *"
     }
   ]
 }


### PR DESCRIPTION
- Fix #53  
- New orgMeta Firestore collection cached by a cron job every 3 days
- DB layer (mapper + db) with validation and serialization
- Sync service fetches org members and repo collaborators from GitHub
- Cron route at /api/cron/sync-org-meta (schedule: 30 21 */3 * * UTC)
- Registered in vercel.json and manual-cron-jobs service
- fetchUnansweredIssues reads cached org data first, falls back to GitHub API
- Updated db-schema.md with orgMeta collection documentation
- Reduce unanswered issues window from 30 to 15 days